### PR TITLE
Added parsing string for "{$variable}" cases

### DIFF
--- a/php-class-splitter.php
+++ b/php-class-splitter.php
@@ -18,23 +18,26 @@ while ($token = next($tokens)) {
                 && empty($name)) {
                 $name = $token[1];
             }
-        } while (!(is_string($token) && $token == '{') && $token = next($tokens));
+        } while (!(is_string($token) && $token === '{') && !(is_array($token) && $token[1] == '{') && $token = next($tokens));
     } elseif ($buffer) {
-        if (is_string($token)) {
-            $code .= $token;
-            if ($token == '{') {
-                $braces++;
-            } elseif ($token == '}') {
-                $braces--;
-                if ($braces == 0) {
-                    $buffer = false;
-                    $file = $dest . '/' . $name . '.php';
-                    $code = '<?php' . PHP_EOL . $code;
-                    file_put_contents($file, $code); 
-                }
+
+        if (is_array($token)) {
+            $token = $token[1];
+        }
+
+        $code .= $token;
+
+        if ($token == '{') {
+            $braces++;
+        } elseif ($token == '}') {
+            $braces--;
+            if ($braces == 0) {
+                $buffer = false;
+                $file = $dest . '/' . $name . '.php';
+                $code = '<?php' . PHP_EOL . $code;
+                file_put_contents($file, $code);
             }
-        } else {
-            $code .= $token[1];
         }
     }
 }
+


### PR DESCRIPTION
I was trying to split classes using multi line "" strings including "{$variable}" and the first { token was an array, while the last was just a string '}', so the count of { and } wasn't paired.

This fix worked for me